### PR TITLE
Patch performance issue

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,17 +1,21 @@
+import _mkdirp from 'mkdirp';
 import path from 'path';
 import { parse as parseYaml } from 'yaml';
 import { promises as fsPromises } from 'fs';
 import glob from 'fast-glob';
 import getHash from './hash';
 import createCodegenOpts from './lib/create-codegen-opts';
+import genDts from './lib/gen-dts';
 import { createPaths } from './lib/paths';
-import { codegen } from './lib/codegen';
+import { processGraphQLCodegen, wrapAsModule } from './lib/codegen';
+import { printInfo } from './lib/print';
 import { CommandOpts, ConfigTypes } from './lib/types';
 import { promisify } from 'util';
 import _rimraf from 'rimraf';
 
+const mkdirp = promisify(_mkdirp);
 const rimraf = promisify(_rimraf);
-const { readFile } = fsPromises;
+const { readFile, writeFile } = fsPromises;
 
 export default async function gen(commandOpts: CommandOpts): Promise<void> {
   const { configPath, cwd } = commandOpts;
@@ -30,6 +34,14 @@ export default async function gen(commandOpts: CommandOpts): Promise<void> {
     );
   }
 
+  // XXX: Rough implementation to patch a performance issue
+  const tsSources: {
+    tsxFullPath: string;
+    dtsFullPath: string;
+    dtsRelPath: string;
+    gqlRelPath: string;
+  }[] = [];
+
   for (const gqlRelPath of gqlRelPaths) {
     const gqlContent = await readFile(path.join(cwd, gqlRelPath), 'utf-8');
 
@@ -40,14 +52,28 @@ export default async function gen(commandOpts: CommandOpts): Promise<void> {
       getHash(gqlContent),
     );
 
-    await codegen(
-      gqlContent,
-      gqlRelPath,
-      tsxFullPath,
-      dtsRelPath,
-      dtsFullPath,
-      config,
+    await processGraphQLCodegen(
       codegenOpts,
+      tsxFullPath,
+      gqlRelPath,
+      gqlContent,
     );
+
+    tsSources.push({ tsxFullPath, dtsFullPath, gqlRelPath, dtsRelPath });
+  }
+
+  await mkdirp(path.dirname(tsSources[0].dtsFullPath));
+
+  const dtsContents = genDts(tsSources.map(s => s.tsxFullPath));
+
+  for (let i = 0; i < tsSources.length; i++) {
+    const { dtsFullPath, gqlRelPath, dtsRelPath } = tsSources[i]!;
+    const dtsContent = dtsContents[i]!;
+
+    await writeFile(
+      dtsFullPath,
+      wrapAsModule(path.basename(gqlRelPath), dtsContent),
+    );
+    printInfo(`${dtsRelPath} was generated.`);
   }
 }

--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -16,12 +16,12 @@ const mkdirp = promisify(_mkdirp);
 // For the loader can process a same file simultaneously
 const processingTasks = new Map<string /*fileFullPath*/, Promise<string>>();
 
-function wrapAsModule(fileName: string, content: string) {
+export function wrapAsModule(fileName: string, content: string) {
   return `declare module '*/${fileName}' {
   ${content.replace(/\n/g, '\n  ')}}`;
 }
 
-async function processGraphQLCodegen(
+export async function processGraphQLCodegen(
   codegenOpts: PartialCodegenOpts,
   tsxFullPath: string,
   gqlRelPath: string,
@@ -49,7 +49,7 @@ async function processGenDts(
   dtsRelPath: string,
 ) {
   await mkdirp(path.dirname(dtsFullPath));
-  const dtsContent = await genDts(tsxFullPath);
+  const [dtsContent] = await genDts([tsxFullPath]);
   if (!dtsContent) throw new Error(`Generate ${dtsFullPath} fails.`);
   await writeFile(
     dtsFullPath,

--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -24,7 +24,7 @@ function wrapAsModule(fileName: string, content: string) {
 async function processGraphQLCodegen(
   codegenOpts: PartialCodegenOpts,
   tsxFullPath: string,
-  gqlFullPath: string,
+  gqlRelPath: string,
   gqlContent: string,
 ): Promise<string> {
   const tsxContent = await graphqlCodegen({
@@ -32,7 +32,7 @@ async function processGraphQLCodegen(
     filename: tsxFullPath,
     documents: [
       {
-        filePath: gqlFullPath,
+        filePath: gqlRelPath,
         content: gql(gqlContent),
       },
     ],
@@ -45,7 +45,7 @@ async function processGraphQLCodegen(
 async function processGenDts(
   dtsFullPath: string,
   tsxFullPath: string,
-  gqlFullPath: string,
+  gqlRelPath: string,
   dtsRelPath: string,
 ) {
   await mkdirp(path.dirname(dtsFullPath));
@@ -53,7 +53,7 @@ async function processGenDts(
   if (!dtsContent) throw new Error(`Generate ${dtsFullPath} fails.`);
   await writeFile(
     dtsFullPath,
-    wrapAsModule(path.basename(gqlFullPath), dtsContent),
+    wrapAsModule(path.basename(gqlRelPath), dtsContent),
   );
   printInfo(`${dtsRelPath} was generated.`);
   return dtsContent;
@@ -61,7 +61,7 @@ async function processGenDts(
 
 export async function codegen(
   gqlContent: string,
-  gqlFullPath: string,
+  gqlRelPath: string,
   tsxFullPath: string,
   dtsRelPath: string,
   dtsFullPath: string,
@@ -77,7 +77,7 @@ export async function codegen(
     const tsxPromise = processGraphQLCodegen(
       codegenOpts,
       tsxFullPath,
-      gqlFullPath,
+      gqlRelPath,
       gqlContent,
     );
     processingTasks.set(tsxFullPath, tsxPromise);
@@ -91,7 +91,7 @@ export async function codegen(
     const dtsPromise = processGenDts(
       dtsFullPath,
       tsxFullPath,
-      gqlFullPath,
+      gqlRelPath,
       dtsRelPath,
     );
     processingTasks.set(dtsFullPath, dtsPromise);

--- a/src/lib/gen-dts.ts
+++ b/src/lib/gen-dts.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { createCompilerHost, createProgram, CompilerOptions } from 'typescript';
 
 const options: CompilerOptions = {
@@ -6,19 +7,31 @@ const options: CompilerOptions = {
   skipLibCheck: false,
 };
 
-export default function genDts(inputFileName: string): string {
-  let outputText = '';
+export default function genDts(tsxFullPaths: string[]): string[] {
   const compilerHost = createCompilerHost({});
-  compilerHost.writeFile = (name, text) => {
-    outputText = text;
+
+  const dtsContents: string[] = [];
+  compilerHost.writeFile = (name, dtsContent) => {
+    // To make sure the order of input files and call of "writeFile" consistent
+    const pathFragment = path.join(
+      path.dirname(name),
+      path.basename(name, '.d.ts'),
+    );
+    const tsxFullPath = tsxFullPaths[dtsContents.length];
+    if (!tsxFullPath.startsWith(pathFragment)) {
+      throw new Error(
+        'TypeScript API was not expected as graphql-let developer, it needs to be fixed',
+      );
+    }
+    dtsContents.push(dtsContent);
   };
 
-  const program = createProgram([inputFileName], options, compilerHost);
+  const program = createProgram(tsxFullPaths, options, compilerHost);
   program.emit();
 
-  if (!outputText) {
+  if (dtsContents.length !== tsxFullPaths.length) {
     throw new Error('Fails to generate .d.ts.');
   }
 
-  return outputText;
+  return dtsContents;
 }


### PR DESCRIPTION
Ref. #24

## As-Is
It runs the TypeScript API the number of `.graphql` files times.

## To-Be
It runs the TypeScript API once.

## Improvement
I tried 100 documents with the Next.js with-typescript-graphql example. It used to take 3m39.528s and now 6.778s. **It reduces 97%**.