### PR TITLE
Pass config options to graphql-code-generator

### DIFF
--- a/src/lib/create-codegen-opts.ts
+++ b/src/lib/create-codegen-opts.ts
@@ -60,10 +60,7 @@ export default async function createCodegenOpts(
   cwd: string,
 ): Promise<PartialCodegenOpts> {
   return {
-    config: {
-      withHOC: false, // True by default
-      withHooks: true, // False by default
-    },
+    config: config.config,
     schema: await generateSchema(config.schema, config.respectGitIgnore, cwd),
     plugins: config.plugins.map(name => ({ [name]: {} })),
     pluginMap: config.plugins.reduce((acc, name) => {


### PR DESCRIPTION
Should fix #57.

If we want some default config either add it as a fallback, or add it to the initially generated `.graphql-let.yml` file.