### PR TITLE
fix: locked major version of globby to prevent issue #64

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "loader.js"
   ],
   "dependencies": {
-    "globby": "*",
+    "globby": "^11.0.0",
     "loader-utils": "^1.4.0",
     "log-update": "^4.0.0",
     "make-dir": "^3.0.2",
     "minimist": "^1.2.0",
     "rimraf": "^3.0.2",
-    "slash": "*",
+    "slash": "^3.0.0",
     "yaml": "^1.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I believe this change should prevent https://github.com/piglovesyou/graphql-let/issues/64.

I also locked the major version of `slash`. I haven't witnessed a problem related to this but "better safe than sorry".