### PR TITLE
Accept path to config file as argument

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,12 +1,14 @@
 import minimist from 'minimist';
+import { basename, dirname, resolve } from 'path';
 import { printError } from './lib/print';
 import { CommandOpts } from './lib/types';
 
 const argv = minimist(process.argv.slice(2));
 const HELP_TEXT = `Usage: graphql-let [command]
 
-graphql-let         Generates .graphql.d.ts beside all GraphQL documents based on .graphql-let.yml config
-graphql-let init    Generates a template of .graphql-let.yml configuration file 
+graphql-let                   Generates .graphql.d.ts beside all GraphQL documents based on .graphql-let.yml config
+graphql-let --config [FILE]   Generates .graphql.d.ts given a config file
+graphql-let init              Generates a template of .graphql-let.yml configuration file 
 `;
 
 if (argv.help || argv.h) {
@@ -30,8 +32,15 @@ switch (argv._[0]) {
 }
 
 function createOpts(): CommandOpts {
-  const cwd = process.cwd();
-  return { cwd };
+  if (argv.config) {
+    return {
+      cwd: resolve(process.cwd(), dirname(argv.config)),
+      configFilePath: basename(argv.config),
+    };
+  } else {
+    const cwd = process.cwd();
+    return { cwd };
+  }
 }
 
 function command(command: string) {

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -8,8 +8,8 @@ import logUpdate from 'log-update';
 export default async function gen(commandOpts: CommandOpts): Promise<void> {
   logUpdate(PRINT_PREFIX + 'Running graphql-codegen...');
 
-  const { cwd } = commandOpts;
-  const [config, configHash] = await loadConfig(cwd);
+  const { cwd, configFilePath } = commandOpts;
+  const [config, configHash] = await loadConfig(cwd, configFilePath);
 
   const numberAffected = await fullGenerate(cwd, config, configHash);
 

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -7,8 +7,9 @@ import getHash from './hash';
 
 export default async function loadConfig(
   cwd: string,
+  configFilePath?: string,
 ): Promise<[ConfigTypes, string]> {
-  const configPath = pathJoin(cwd, DEFAULT_CONFIG_FILENAME);
+  const configPath = pathJoin(cwd, configFilePath || DEFAULT_CONFIG_FILENAME);
   const content = await readFile(configPath, 'utf-8');
   const configHash = await getHash(content);
   const config: ConfigTypes = parseYaml(content);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type CommandOpts = {
   cwd: string;
+  configFilePath?: string;
 };
 
 export type ConfigTypes = {


### PR DESCRIPTION
First, good job for this tool.

We want to use it on our codebase, but we currently have some limitations that do not allow us to put the `.graphql-let.yml` at the root of our workspace.

Generation of `.d.ts` by the Webpack loader on its own only is currently too slow to rely on it for the development server or even the build.

So this PR simply adds a `--config` argument to specify path to the desired config file.

```sh
graphql-let --config ./src/.graphql-let.yml
```

Passing a Config File will also set the `CWD` to the folder of this file.

Ideally it should also be available as a Webpack Loader option.