### PR TITLE
Fix the link for all available plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npx graphql-let init
 ```
 
 Next add
-[graphql-codegen plugins](https://graphql-code-generator.com/docs/plugins/#available-plugins)
+[graphql-codegen plugins](https://graphql-code-generator.com/docs/plugins/index)
 in it. **Please note that you have to generate TypeScript source** by the
 plugins.
 


### PR DESCRIPTION
It seems that the link has changed and the old link is not available
anymore. This commit fixes this.