### PR TITLE
fix unable to set respectGitIgnore config flag to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-let",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:piglovesyou/graphql-let.git"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -47,7 +47,8 @@ export function buildConfig(raw: UserConfigTypes): ConfigTypes {
     // Normalized codegen options
     documents,
     // Set graphql-let default values
-    respectGitIgnore: raw.respectGitIgnore || true,
+    respectGitIgnore:
+      raw.respectGitIgnore !== undefined ? raw.respectGitIgnore : true,
     cacheDir: raw.cacheDir || 'node_modules/graphql-let/__generated__',
     TSConfigFile: raw.TSConfigFile || 'tsconfig.json',
     gqlDtsEntrypoint:


### PR DESCRIPTION
Simple fix to "respectGitIgnore: false" not working in config ( #146 )

I thought about just replacing the "||" with the null-coalescing operator "??", but since the typescript compilation target seems to be set to "esnext", the resulting js code would only work in NodeJS 14 and up I think.

Sorry I didn't bother making any automated tests because half of the current tests failed for me before even making any changes. But I tried it manually and this fix seemed to work.