### PR TITLE
fix: Veil deps stdout and control it by log-update

### DIFF
--- a/src/lib/graphql-codegen.ts
+++ b/src/lib/graphql-codegen.ts
@@ -38,6 +38,7 @@ export function buildCodegenConfig(
   }
 
   return {
+    silent: true,
     ...config,
     // @ts-ignore
     cwd,

--- a/src/lib/resolver-types.ts
+++ b/src/lib/resolver-types.ts
@@ -107,6 +107,7 @@ export default typeof DocumentNode
       );
 
       await processGraphQLCodegen(execContext, [context], {
+        silent: true,
         ...config,
         cwd,
         generates: {


### PR DESCRIPTION
The internal GraphQL code generator outs stdout since around graphql-let@0.15.x, from we use API from @graphql-codegen/cli .
![Screen Shot 2020-10-04 at 14 35 17](https://user-images.githubusercontent.com/217530/95007814-e5599080-064e-11eb-97af-626309aa18a1.png)

Because of it, our log-update doesn't work as intended. I'll make it silent. I believe there's less downside because enough error messages follow if any.