### PR TITLE
Better graphql sytax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-let",
-  "version": "0.18.3",
+  "version": "0.18.4-beta.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:piglovesyou/graphql-let.git"

--- a/src/call-expressions/type-inject.ts
+++ b/src/call-expressions/type-inject.ts
@@ -56,24 +56,14 @@ export function resolveGraphQLDocument(
   // This allows to start from content of GraphQL document, not file path
   const predefinedImports = { [importRootPath]: gqlContent };
   const map: VisitedFilesMap = new Map();
-  try {
-    const documentNode = processImport(
-      importRootPath,
-      cwd,
-      predefinedImports,
-      map,
-    );
-    const dependantFullPaths = Array.from(map.keys());
-    return { documentNode, dependantFullPaths };
-  } catch (e) {
-    // Reformat error log to include source file and position information
-    const { body, name } = e.source;
-    const stack = e.stack.split('\n').slice(1).join('\n');
-    const [{ line, column }] = e.locations;
-    e.message = `${name}; ${e.message}\nIn line ${line}, column ${column} of the following source:\n${body}`;
-    e.stack = stack;
-    throw e;
-  }
+  const documentNode = processImport(
+    importRootPath,
+    cwd,
+    predefinedImports,
+    map,
+  );
+  const dependantFullPaths = Array.from(map.keys());
+  return { documentNode, dependantFullPaths };
 }
 
 export function prepareAppendTiContext(

--- a/src/gen.test.ts
+++ b/src/gen.test.ts
@@ -112,7 +112,8 @@ describe('"graphql-let" command', () => {
     try {
       await gen({ cwd });
     } catch (e) {
-      expect(printedMessages.length).toBe(2); // TODO: Why 2?
+      // Two for __types__.tsx and viewer.grpahql.tsx
+      expect(printedMessages.length).toBe(2);
       expect(printedMessages[0]).toContain(`Failed to load schema
         Failed to load schema from **/*.graphqls:
 

--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -163,11 +163,9 @@ async function processGraphQLCodegen(
   } catch (error) {
     if (error.name === 'ListrError' && error.errors != null) {
       for (const err of error.errors) {
-        err.message = `${err.message}${err.details || ''}`;
+        if (err.details) err.message = `${err.message}${err.details}`;
         printError(err);
       }
-    } else {
-      printError(error);
     }
     throw error;
   }

--- a/src/lib/print.ts
+++ b/src/lib/print.ts
@@ -11,7 +11,7 @@ export function printWarning(message: string): void {
 }
 
 export function printError(err: Error): void {
-  console.error(PRINT_PREFIX + err.message + '\n' + err.stack);
+  console.error(PRINT_PREFIX + err.toString() + '\n' + err.stack);
 }
 
 export function updateLog(message: string) {


### PR DESCRIPTION
I should have used `error.toString()` to print better GraphQLError syntax errors.