### PR TITLE
Defaulted to original settings due to specificy of how plugins' configs merged prior generating typings

### DIFF
--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -33,6 +33,9 @@ function getOptionalSchemaPlugins() {
 function getFixedSchemaConfig() {
   return {
     plugins: ['typescript', ...getOptionalSchemaPlugins()],
+    config: {
+      typesPrefix: '',
+    },
   };
 }
 


### PR DESCRIPTION
# Motivation:

Imagine case when you wanted to generate `type safe` Documents (which most of the cases used whenever you wanted to use `Document` directly decoupled from `react hook` and in this case you have two options (due to way of how `graphql-codegen` plugin system built:

1. Deal with it via type casting like so (pseudo code):
```ts
import { GeneratedDocument, Query, Variables } from './some.graphql';
import { client } from './previously-initialized-client-file';
...
const onSubmit = (variables) => client.query({ query: GeneratedDocument as unknown as TypedDocument<Query, Variables>, ...});

```

2. **(Proposed solution)** Split onto separate file documents, make it `pure` and `sideEffects` free in order to deal with bundle size and use following config for `graphql-let` in conjunction  with additionally generated file from `graphql-codegen` prior `graphql-let` cli starts (e.g. via `pre<script>` command):

`.graphql-let.yml`
```yml
schema: "schema.graphql"
documents:
  - "**/src/**/*.graphql"
  # We should NOT include fragments or any meta info here, it's responsibility of proposed solution (separate documents file)
  - "!**/src/**/*.fragment.graphql"
plugins:
  # Pretty much any client out there
  - typescript-urql
  - add:
      content: "/* eslint-disable */"
cacheDir: ".cache/graphql-let"
generateOptions: 111
config:
  useTypeImports: true

  namingConvention:
    # This one actually needed, because issue with documentVariablePrefix mangled with dot notation, but it could be fixed with case-casting file (below, or similar)
    typeNames: "keep/case-casting.js"
  documentMode: "external"
  importDocumentNodeExternallyFrom: "some-path/documents"
  importOperationTypesFrom: "some-path/documents"
  # because it would be added by ClientSide visitor when importOperationTypesFrom used
  typesPrefix: "Operations."
  documentVariablePrefix: "Operations."
```

`case-casting.js`
```js
const { pascalCase } = require('change-case-all');

const stripRegexp = /[^A-Z0-9\\.]/gi;

const splitRegexp = [
  /([a-z0-9]|[.])([A-Z])/g,
  /([a-z0-9][.])([a-z])/g,
  /([A-Z])([A-Z][a-z])/g,
];

module.exports = {
  preserveDot: (str) =>
    pascalCase(str, {
      stripRegexp,
      splitRegexp,
    }),
};
```


`codegen.yml`
```yml

schema: "schema.graphql"
documents:
  - "**/*.graphql" // In order to conform unnecessary types
extensions:
  codegen:
    config:
      experimentalFragmentVariables: true
      useTypeImports: true
      dedupeFragments: true
    generates:
      "some-path/documents/index.ts":
        preset: import-types
        presetConfig:
          typesPath: "graphql-let/__generated__/__types__"
          # In order to avoid some type conflicts
          importTypesNamespace: "GraphQL_Let_Types"
        config:
          # Bundlesize matters! ✊🏻 
          pureMagicComment: true
        plugins:
          # Type safety here!
          - typed-document-node 
          - typescript-operations
          - add:
              content: "/* eslint-disable */" 
              placement: 'prepend'


```

# Expected behaviour:

All generated files for custom plugins in case of #2 mentioned above would properly generate set of files whenever TS would be happy and it won't disrupt any built processes whenever it would still working as expected, due it would only affects one place which actually **expected behaviour** – `SchemaTypes` (also now its provided `typescript-resolvers` plugin under `OPTIONAL_SCHEMA_PLUGINS` however for that only case this is still something NON issue due to how that plugin generates output and what are expected incoming params), however you would never receive any issues with schema typings.

# Proposed solution:

In this PR we are defaulting to `typescript` plugin to what it tended to be, because with setup mentioned above (#2) it would be generated with `Operations.SomeType` signature and fail to emit from `TS` compiler, however it should always contradict to Schema (or can be controlled via options, e.g. per generated file basis OR via `generateOptions` which currently not utilised or anyhow else if somebody would still need to prefix on `schema-import` file and  on other generated files as well to contradict those changes in importing file)
Because of it's opinionated it should be outlined in `README.md` however we could also introduce some configuration for it because comment states following 😋 : 
```
// To avoid unnecessary complexity, graphql-let controls
// all the presets including plugin options related to it as its spec.
// I think it works for many of users, but there could be
// cases where you need to configure this more. Issue it then.
```

But minimal set of changes (although they kinda opinionated) provided in following PR.

Thoughts @piglovesyou / maintainers ❓ 