### PR TITLE
Fix for ts-jest as subsequentTransformer

### DIFF
--- a/src/jestTransformer.ts
+++ b/src/jestTransformer.ts
@@ -51,6 +51,13 @@ const jestTransformer: SyncTransformer<JestTransformerOptions> = {
       const _subsequentTransformer = getDefaultExportIfExists(
         subsequentTransformer,
       );
+
+      if ('createTransformer' in _subsequentTransformer) {
+        return _subsequentTransformer
+          .createTransformer({ cwd: cwd })
+          .process(tsxContent, tsxFullPath, ...rest);
+      }
+
       return _subsequentTransformer.process(tsxContent, tsxFullPath, ...rest);
     }
 


### PR DESCRIPTION
Should fix #470. 

`ts-jest` does not directly make a `process` method available from its default export. 