### PR TITLE
Fix jestTransformer when using moved cache + config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ You're seeing the `*2`. It's used to skip `*1` and `*3`, and recodnized as gener
 -   **[Create an issue](https://github.com/piglovesyou/graphql-let/issues/new)**
     if you have ideas, find a bug, or anything.
 -   **Creating a PR** is always welcome!
-    -   Running `npm run prepublishOnly` locally will get your local development
+    -   Running `yarn run prepack` locally will get your local development
         ready.
     -   Adding tests is preferable, but not necessary. Maybe someone else will
         fill it.

--- a/src/__fixtures/jestTransformerCustomPaths/subdir/.graphql-let.yml
+++ b/src/__fixtures/jestTransformerCustomPaths/subdir/.graphql-let.yml
@@ -1,0 +1,7 @@
+schema: ./schema/type-defs.graphqls
+documents: "**/*.graphql"
+plugins:
+    - typescript-operations
+    - typescript-react-apollo
+respectGitIgnore: true
+cacheDir: ../.cache

--- a/src/__fixtures/jestTransformerCustomPaths/subdir/babel.config.json
+++ b/src/__fixtures/jestTransformerCustomPaths/subdir/babel.config.json
@@ -1,0 +1,7 @@
+{
+  presets: [
+    '@babel/preset-env',
+    '@babel/preset-typescript',
+    '@babel/preset-react',
+  ],
+}

--- a/src/__fixtures/jestTransformerCustomPaths/subdir/pages/viewer.graphql
+++ b/src/__fixtures/jestTransformerCustomPaths/subdir/pages/viewer.graphql
@@ -1,0 +1,7 @@
+query Viewer {
+    viewer {
+        id
+        name
+        status
+    }
+}

--- a/src/__fixtures/jestTransformerCustomPaths/subdir/schema/type-defs.graphqls
+++ b/src/__fixtures/jestTransformerCustomPaths/subdir/schema/type-defs.graphqls
@@ -1,0 +1,9 @@
+type User {
+    id: ID!
+    name: String!
+    status: String!
+}
+
+type Query {
+    viewer: User
+}

--- a/src/__snapshots__/jestTransformer.test.ts.snap
+++ b/src/__snapshots__/jestTransformer.test.ts.snap
@@ -60,3 +60,64 @@ function useViewerLazyQuery(baseOptions) {
   return Apollo.useLazyQuery(ViewerDocument, options);
 }"
 `;
+
+exports[`graphql-let/jestTransformer transforms .graphql when custom configFile and cache dirs set 1`] = `
+"\\"use strict\\";
+
+function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports.useViewerQuery = useViewerQuery;
+exports.useViewerLazyQuery = useViewerLazyQuery;
+exports.ViewerDocument = void 0;
+
+var Apollo = _interopRequireWildcard(require(\\"@apollo/client\\"));
+
+var _templateObject;
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== \\"object\\" && typeof obj !== \\"function\\") { return { \\"default\\": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj[\\"default\\"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+
+var defaultOptions = {};
+var ViewerDocument = (0, Apollo.gql)(_templateObject || (_templateObject = _taggedTemplateLiteral([\\"\\\\n    query Viewer {\\\\n  viewer {\\\\n    id\\\\n    name\\\\n    status\\\\n  }\\\\n}\\\\n    \\"])));
+/**
+ * __useViewerQuery__
+ *
+ * To run a query within a React component, call \`useViewerQuery\` and pass it any options that fit your needs.
+ * When your component renders, \`useViewerQuery\` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useViewerQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+
+exports.ViewerDocument = ViewerDocument;
+
+function useViewerQuery(baseOptions) {
+  var options = _objectSpread(_objectSpread({}, defaultOptions), baseOptions);
+
+  return Apollo.useQuery(ViewerDocument, options);
+}
+
+function useViewerLazyQuery(baseOptions) {
+  var options = _objectSpread(_objectSpread({}, defaultOptions), baseOptions);
+
+  return Apollo.useLazyQuery(ViewerDocument, options);
+}"
+`;

--- a/src/jestTransformer.ts
+++ b/src/jestTransformer.ts
@@ -1,11 +1,11 @@
 import { SyncTransformer } from '@jest/transform';
 import { ProjectConfig } from '@jest/types/build/Config';
 import { readFileSync } from 'fs';
+import { dirname, relative, resolve } from 'path';
 import { loadConfigSync } from './lib/config';
 import { createExecContextSync } from './lib/exec-context';
 import { createHash } from './lib/hash';
 import { createPaths } from './lib/paths';
-import { dirName, relative, resolve } from 'path';
 
 export type JestTransformerOptions = {
   configFile?: string;
@@ -42,8 +42,8 @@ const jestTransformer: SyncTransformer<JestTransformerOptions> = {
     const { configFile, subsequentTransformer } = getOption(jestConfig);
     // If the congFile is in another directory from jest's rootDir, reset the working path since
     // since the cache and transforms will operate relative to that config's location
-    const cwd = resolve(cwd, dirname(configFile));
     const [config, configHash] = loadConfigSync(cwd, configFile);
+    cwd = configFile ? resolve(cwd, dirname(configFile)) : cwd;
     const { execContext } = createExecContextSync(cwd, config, configHash);
 
     const { tsxFullPath } = createPaths(execContext, relative(cwd, sourcePath));

--- a/src/jestTransformer.ts
+++ b/src/jestTransformer.ts
@@ -1,11 +1,11 @@
 import { SyncTransformer } from '@jest/transform';
 import { ProjectConfig } from '@jest/types/build/Config';
 import { readFileSync } from 'fs';
-import { relative } from 'path';
 import { loadConfigSync } from './lib/config';
 import { createExecContextSync } from './lib/exec-context';
 import { createHash } from './lib/hash';
 import { createPaths } from './lib/paths';
+import { dirName, relative, resolve } from 'path';
 
 export type JestTransformerOptions = {
   configFile?: string;
@@ -38,8 +38,11 @@ const jestTransformer: SyncTransformer<JestTransformerOptions> = {
     const [__compatJestConfig] = rest;
     const jestConfig = __compatJestConfig?.config ?? __compatJestConfig;
     // jest v26 vs v27 changes to support both formats: end
-    const { rootDir: cwd } = jestConfig;
+    let { rootDir: cwd } = jestConfig;
     const { configFile, subsequentTransformer } = getOption(jestConfig);
+    // If the congFile is in another directory from jest's rootDir, reset the working path since
+    // since the cache and transforms will operate relative to that config's location
+    const cwd = resolve(cwd, dirname(configFile));
     const [config, configHash] = loadConfigSync(cwd, configFile);
     const { execContext } = createExecContextSync(cwd, config, configHash);
 


### PR DESCRIPTION
Partially addresses #605 

Sets a new cwd context in cases where the config file does not reside in the jest root directory. This is necessary because the config file can then give the cache location, but it will be relative to its own location (not that of the jest config)