### PR TITLE
Update Minimist; loosen to use caret dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "loader-utils": "2.0.0",
     "log-update": "4.0.0",
     "make-dir": "3.1.0",
-    "minimist": "1.2.5",
+    "minimist": "^1.2.6",
     "schema-utils": "3.0.0",
     "slash": "3.0.0",
     "string-env-interpolation": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8541,7 +8541,7 @@ fsevents@~2.3.1:
     log-update: 4.0.0
     make-dir: 3.1.0
     memory-fs: 0.5.0
-    minimist: 1.2.5
+    minimist: ^1.2.6
     p-map: 4.0.0
     prettier: 2.2.1
     prettier-plugin-organize-imports: 1.1.1
@@ -11478,10 +11478,10 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"minimist@npm:1.2.5, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Minimist had a security notice on 1.2.5 which is triggering dependabot, and projects using graphql-let may want to update to avoid that notice.

Additionally, start using caret semver dependencies as this usage allows downstream projects to upgrade around security issues without needing to re-release graphql-let itself. Generally the counter argument to this is that an upstream _could_ release a breaking change without proper semver and that would break downstream projects. But in practice, that risk is generally minimal and this trades in that security for more responsiveness (and hopefully less maintinance). For instance, notice that three upstream projects of graphql-let also use minimist, but we don't have to upgrade those!