### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.18.7",
   "repository": {
     "type": "git",
-    "url": "git@github.com:piglovesyou/graphql-let.git"
+    "url": "git+https://github.com/piglovesyou/graphql-let.git"
   },
   "homepage": "https://github.com/piglovesyou/graphql-let",
   "author": "Soichi Takamura <thepiglovesyou@gmail.com>",


### PR DESCRIPTION
## Summary
- Switch the package repository metadata from the SSH-style GitHub URL to the public HTTPS Git URL.

## Validation
- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/piglovesyou/graphql-let.git') process.exit(1)"`
- `node .yarn/releases/yarn-4.0.2.cjs install --immutable --mode=skip-build`
- `NODE_OPTIONS=--openssl-legacy-provider node .yarn/releases/yarn-4.0.2.cjs lint`
- `NODE_OPTIONS=--openssl-legacy-provider node .yarn/releases/yarn-4.0.2.cjs typecheck`
- `NODE_OPTIONS=--openssl-legacy-provider node .yarn/releases/yarn-4.0.2.cjs build`
- `NODE_OPTIONS=--openssl-legacy-provider node .yarn/releases/yarn-4.0.2.cjs test --runInBand` (10 suites, 30 passed, 1 skipped)
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: the `NODE_OPTIONS` flag is needed in this local Node 24 environment because webpack 4 otherwise hits the OpenSSL 3 `ERR_OSSL_EVP_UNSUPPORTED` compatibility issue.
